### PR TITLE
HotFix: added x-forwarded-proto for originial request scheme

### DIFF
--- a/cvat/nginx.conf
+++ b/cvat/nginx.conf
@@ -91,6 +91,7 @@ http {
 
     location / {
       proxy_set_header Host $http_host;
+      proxy_set_header X-Forwarded-Proto $scheme;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection $connection_upgrade;


### PR DESCRIPTION
Fixes the issue while downloading annotation over https